### PR TITLE
git-branches: Move away from legacy package, simplify.

### DIFF
--- a/git-branches/branches.go
+++ b/git-branches/branches.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os/exec"
+	"strings"
+
+	"github.com/shurcooL/go/pipe_util"
+	"github.com/shurcooL/go/trim"
+	"gopkg.in/pipe.v2"
+)
+
+// BranchesOptions are options for Branches.
+type BranchesOptions struct {
+	Base string // Base branch to compare against (if blank, defaults to "master").
+}
+
+// fillMissing sets default values for mandatory options that are left empty.
+func (opt *BranchesOptions) fillMissing() {
+	if opt.Base == "" {
+		opt.Base = "master"
+	}
+}
+
+// Branches returns a Markdown table of branches with ahead/behind information relative to master branch.
+func Branches(dir string, localBranch string, opt BranchesOptions) string {
+	opt.fillMissing()
+	branchInfo := func(line []byte) []byte {
+		branch := trim.LastNewline(string(line))
+		branchDisplay := branch
+		if branch == localBranch {
+			branchDisplay = "**" + branch + "**"
+		}
+
+		cmd := exec.Command("git", "rev-list", "--count", "--left-right", opt.Base+"..."+branch)
+		cmd.Dir = dir
+		out, err := cmd.Output()
+		if err != nil {
+			log.Printf("error running %v: %v\n", cmd.Args, err)
+			return []byte(fmt.Sprintf("%s | ? | ?\n", branchDisplay))
+		}
+
+		behindAhead := strings.Split(trim.LastNewline(string(out)), "\t")
+		return []byte(fmt.Sprintf("%s | %s | %s\n", branchDisplay, behindAhead[0], behindAhead[1]))
+	}
+
+	p := pipe.Script(
+		pipe.Println("Branch | Behind | Ahead"),
+		pipe.Println("-------|-------:|:-----"),
+		pipe.Line(
+			pipe.Exec("git", "for-each-ref", "--format=%(refname:short)", "refs/heads"),
+			pipe.Replace(branchInfo),
+		),
+	)
+
+	out, err := pipe_util.OutputDir(p, dir)
+	if err != nil {
+		return err.Error()
+	}
+	return string(out)
+}
+
+// Input is a line containing tab-separated local branch and remote branch.
+// For example, "master\torigin/master".
+func branchRemoteInfo(dir string, localBranch string) func(line []byte) []byte {
+	return func(line []byte) []byte {
+		branchRemote := strings.Split(trim.LastNewline(string(line)), "\t")
+		if len(branchRemote) != 2 {
+			return []byte("error: len(branchRemote) != 2")
+		}
+
+		branch := branchRemote[0]
+		branchDisplay := branch
+		if branch == localBranch {
+			branchDisplay = "**" + branch + "**"
+		}
+
+		remote := branchRemote[1]
+		if remote == "" {
+			return []byte(fmt.Sprintf("%s | | | \n", branchDisplay))
+		}
+
+		cmd := exec.Command("git", "rev-list", "--count", "--left-right", remote+"..."+branch)
+		cmd.Dir = dir
+		out, err := cmd.Output()
+		if err != nil {
+			// This usually happens when the remote branch is gone.
+			remoteDisplay := "~~" + remote + "~~"
+			return []byte(fmt.Sprintf("%s | %s | | \n", branchDisplay, remoteDisplay))
+		}
+
+		behindAhead := strings.Split(trim.LastNewline(string(out)), "\t")
+		return []byte(fmt.Sprintf("%s | %s | %s | %s\n", branchDisplay, remote, behindAhead[0], behindAhead[1]))
+	}
+}
+
+// BranchesRemote returns a Markdown table of branches with ahead/behind information relative to remote.
+func BranchesRemote(dir string, localBranch string) string {
+	p := pipe.Script(
+		pipe.Println("Branch | Remote | Behind | Ahead"),
+		pipe.Println("-------|--------|-------:|:-----"),
+		pipe.Line(
+			pipe.Exec("git", "for-each-ref", "--format=%(refname:short)\t%(upstream:short)", "refs/heads"),
+			pipe.Replace(branchRemoteInfo(dir, localBranch)),
+		),
+	)
+
+	out, err := pipe_util.OutputDir(p, dir)
+	if err != nil {
+		return err.Error()
+	}
+	return string(out)
+}

--- a/git-branches/main.go
+++ b/git-branches/main.go
@@ -9,18 +9,14 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	"github.com/shurcooL/go/exp/12"
-	"github.com/shurcooL/go/u/u6"
-	legacyvcs "github.com/shurcooL/go/vcs"
 	"github.com/shurcooL/markdownfmt/markdown"
-	"sourcegraph.com/sourcegraph/go-vcs/vcs"
-	_ "sourcegraph.com/sourcegraph/go-vcs/vcs/gitcmd"
+	"github.com/shurcooL/vcsstate"
+	"golang.org/x/tools/go/vcs"
 )
 
 var (
 	baseFlag   = flag.String("base", "", "base branch to compare against (only when -remote is not specified)")
 	remoteFlag = flag.Bool("remote", false, "compare local branches against remote")
-	oldFlag    = flag.Bool("old", true, "use old code path")
 )
 
 func main() {
@@ -29,14 +25,9 @@ func main() {
 		fmt.Fprintln(os.Stderr, "warning: -base is ignored when -remote is specified")
 	}
 
-	switch *oldFlag {
-	case false:
-		err := run()
-		if err != nil {
-			log.Fatalln(err)
-		}
-	case true:
-		old()
+	err := run()
+	if err != nil {
+		log.Fatalln(err)
 	}
 }
 
@@ -49,34 +40,42 @@ func run() error {
 	if err != nil {
 		return err
 	}
-	repo, err := vcs.Open("git", dir)
+	vcs, err := vcsstate.NewVCS(vcs.ByCmd("git"))
+	if err != nil {
+		return err
+	}
+	localBranch, err := vcs.Branch(dir)
 	if err != nil {
 		return err
 	}
 
-	base := *baseFlag
-	if base == "" {
-		base = "master"
+	if *remoteFlag {
+		cmd := exec.Command("git", "remote", "update", "--prune")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "git remote update failed:", err)
+			os.Stderr.Write(out)
+		}
 	}
-	opt := vcs.BranchesOptions{
-		BehindAheadBranch: base,
+
+	var branches string
+	switch *remoteFlag {
+	case false:
+		branches = Branches(dir, localBranch, BranchesOptions{Base: *baseFlag})
+	case true:
+		branches = BranchesRemote(dir, localBranch)
 	}
-	branches, err := repo.Branches(opt)
+
+	formatted, err := markdown.Process("", []byte(branches), nil)
 	if err != nil {
 		return err
 	}
+	os.Stdout.Write(formatted)
 
-	fmt.Printf("# Branches (%d total):\n", len(branches))
-	for _, b := range branches {
-		fmt.Printf("-%v | +%v | %s\n", b.Counts.Behind, b.Counts.Ahead, b.Name)
-	}
-
-	// TODO.
-	return fmt.Errorf("not implemented")
+	return nil
 }
 
-// fromDir inspects dir and its parents to determine the
-// version control system and code repository to use.
+// fromDir inspects dir and its parents to determine if it's inside a git repository.
 // On return, root is the path corresponding to the root of the repository.
 func fromDir(dir string) (root string, err error) {
 	dir = filepath.Clean(dir)
@@ -95,41 +94,4 @@ func fromDir(dir string) (root string, err error) {
 	}
 
 	return "", fmt.Errorf("directory %q is not using git", dir)
-}
-
-func old() {
-	dir := exp12.LookupDirectory(".")
-	dir.Update()
-	if dir.Repo == nil {
-		fmt.Fprintln(os.Stderr, "cwd has no git repository")
-		os.Exit(1)
-	}
-	if dir.Repo.Vcs.Type() != legacyvcs.Git {
-		fmt.Fprintln(os.Stderr, "non-git repos are not yet supported")
-		os.Exit(1)
-	}
-
-	if *remoteFlag {
-		cmd := exec.Command("git", "remote", "update", "--prune")
-		out, err := cmd.CombinedOutput()
-		if err != nil {
-			fmt.Fprintln(os.Stderr, "git remote update failed:", err)
-			os.Stderr.Write(out)
-		}
-	}
-	dir.Repo.VcsLocal.Update()
-
-	var branches string
-	switch *remoteFlag {
-	case false:
-		branches = u6.Branches(dir.Repo, u6.BranchesOptions{Base: *baseFlag})
-	case true:
-		branches = u6.BranchesRemote(dir.Repo)
-	}
-
-	formatted, err := markdown.Process("", []byte(branches), nil)
-	if err != nil {
-		panic(err)
-	}
-	os.Stdout.Write(formatted)
 }

--- a/git-branches/main.go
+++ b/git-branches/main.go
@@ -4,17 +4,24 @@ package main
 import (
 	"flag"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
 
 	"github.com/shurcooL/go/exp/12"
 	"github.com/shurcooL/go/u/u6"
-	"github.com/shurcooL/go/vcs"
+	legacyvcs "github.com/shurcooL/go/vcs"
 	"github.com/shurcooL/markdownfmt/markdown"
+	"sourcegraph.com/sourcegraph/go-vcs/vcs"
+	_ "sourcegraph.com/sourcegraph/go-vcs/vcs/gitcmd"
 )
 
-var baseFlag = flag.String("base", "", "base branch to compare against (only when -remote is not specified)")
-var remoteFlag = flag.Bool("remote", false, "compare local branches against remote")
+var (
+	baseFlag   = flag.String("base", "", "base branch to compare against (only when -remote is not specified)")
+	remoteFlag = flag.Bool("remote", false, "compare local branches against remote")
+	oldFlag    = flag.Bool("old", true, "use old code path")
+)
 
 func main() {
 	flag.Parse()
@@ -22,13 +29,82 @@ func main() {
 		fmt.Fprintln(os.Stderr, "warning: -base is ignored when -remote is specified")
 	}
 
+	switch *oldFlag {
+	case false:
+		err := run()
+		if err != nil {
+			log.Fatalln(err)
+		}
+	case true:
+		old()
+	}
+}
+
+func run() error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	dir, err := fromDir(cwd)
+	if err != nil {
+		return err
+	}
+	repo, err := vcs.Open("git", dir)
+	if err != nil {
+		return err
+	}
+
+	base := *baseFlag
+	if base == "" {
+		base = "master"
+	}
+	opt := vcs.BranchesOptions{
+		BehindAheadBranch: base,
+	}
+	branches, err := repo.Branches(opt)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("# Branches (%d total):\n", len(branches))
+	for _, b := range branches {
+		fmt.Printf("-%v | +%v | %s\n", b.Counts.Behind, b.Counts.Ahead, b.Name)
+	}
+
+	// TODO.
+	return fmt.Errorf("not implemented")
+}
+
+// fromDir inspects dir and its parents to determine the
+// version control system and code repository to use.
+// On return, root is the path corresponding to the root of the repository.
+func fromDir(dir string) (root string, err error) {
+	dir = filepath.Clean(dir)
+
+	for {
+		if fi, err := os.Stat(filepath.Join(dir, ".git")); err == nil && fi.IsDir() {
+			return dir, nil
+		}
+
+		// Move to parent.
+		ndir := filepath.Dir(dir)
+		if len(ndir) >= len(dir) {
+			break
+		}
+		dir = ndir
+	}
+
+	return "", fmt.Errorf("directory %q is not using git", dir)
+}
+
+func old() {
 	dir := exp12.LookupDirectory(".")
 	dir.Update()
 	if dir.Repo == nil {
 		fmt.Fprintln(os.Stderr, "cwd has no git repository")
 		os.Exit(1)
 	}
-	if dir.Repo.Vcs.Type() != vcs.Git {
+	if dir.Repo.Vcs.Type() != legacyvcs.Git {
 		fmt.Fprintln(os.Stderr, "non-git repos are not yet supported")
 		os.Exit(1)
 	}


### PR DESCRIPTION
No more unnamed (gist) packages are used for `git-branches`, it now consists of clean idiomatic Go code only.

No longer using `github.com/shurcooL/go/vcs` package that was superseded by `github.com/shurcooL/vcsstate`.

![image](https://cloud.githubusercontent.com/assets/1924134/13911486/9127501e-eeee-11e5-9645-6312ba854e0a.png)
