### PR TITLE
gorepogen: Use GOARCH=js instead of -tags=js for go get -u -d purposes.

### DIFF
--- a/gorepogen/main.go
+++ b/gorepogen/main.go
@@ -38,7 +38,7 @@ Installation
 
 ` + "```bash" + `
 go get -u {{.ImportPath}}{{if .NoGo}}/...{{end}}
-{{if .HasJsTag}}go get -u -d -tags=js {{.ImportPath}}
+{{if .HasJsTag}}GOARCH=js go get -u -d {{.ImportPath}}
 {{end}}` + "```" + `
 {{if not .HasLicenseFile}}
 License


### PR DESCRIPTION
Use GOARCH=js instead of -tags=js because it seems to work for `go get -u -d` purposes (setting the GOARCH value to "js" is equivalent to using "js" build tag), and it's more clear at communicating what the intention of the command is.
