### PR TITLE
gorepogen: Include a directories section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,23 @@ Installation
 go get -u github.com/shurcooL/cmd/...
 ```
 
+Directories
+-----------
+
+| Path                                                                                   | Synopsis                                                                                                           |
+|----------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------|
+| [dump_args](https://godoc.org/github.com/shurcooL/cmd/dump_args)                       | dump_args dumps the command-line arguments.                                                                        |
+| [dump_glfw3_joysticks](https://godoc.org/github.com/shurcooL/cmd/dump_glfw3_joysticks) | dump_glfw3_joysticks dumps state of attached joysticks.                                                            |
+| [dump_httpreq](https://godoc.org/github.com/shurcooL/cmd/dump_httpreq)                 | dump_httpreq dumps incoming HTTP requests with full detail.                                                        |
+| [godoc_router](https://godoc.org/github.com/shurcooL/cmd/godoc_router)                 | godoc_router is a reverse proxy that augments a private godoc server instance with global godoc.org instance.      |
+| [goimporters](https://godoc.org/github.com/shurcooL/cmd/goimporters)                   | goimporters displays an import graph of Go packages that import the specified Go package in your GOPATH workspace. |
+| [goimportgraph](https://godoc.org/github.com/shurcooL/cmd/goimportgraph)               | goimportgraph displays an import graph within specified Go packages.                                               |
+| [gopathshadow](https://godoc.org/github.com/shurcooL/cmd/gopathshadow)                 | gopathshadow reports if you have any shadowed Go packages in your GOPATH workspaces.                               |
+| [gorepogen](https://godoc.org/github.com/shurcooL/cmd/gorepogen)                       | gorepogen generates boilerplate files for Go repositories hosted on GitHub.                                        |
+| [jsonfmt](https://godoc.org/github.com/shurcooL/cmd/jsonfmt)                           | jsonfmt pretty-prints JSON from stdin.                                                                             |
+| [rune_stats](https://godoc.org/github.com/shurcooL/cmd/rune_stats)                     | rune_stats prints counts of total and unique runes from stdin.                                                     |
+| [table](https://godoc.org/github.com/shurcooL/cmd/table)                               | table is a chef client command-line tool.                                                                          |
+
 License
 -------
 

--- a/gorepogen/packages.go
+++ b/gorepogen/packages.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"bufio"
+	"log"
+	"os/exec"
+	"strings"
+)
+
+type pkg struct {
+	ImportPath string
+	Doc        string
+}
+
+// packagesInside returns a list of packages that have root as import path prefix,
+// not including package with import path equal to root.
+func packagesInside(root string) ([]pkg, error) {
+	var pkgs []pkg
+	cmd := exec.Command("go", "list", "-f", "{{.ImportPath}}\t{{.Doc}}", root+"/...")
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	br := bufio.NewReader(stdout)
+	for line, err := br.ReadString('\n'); err == nil; line, err = br.ReadString('\n') {
+		importPathDoc := strings.Split(line[:len(line)-1], "\t") // Trim last newline.
+		if len(importPathDoc) != 2 {
+			log.Fatalf("len(importPathDoc) should be 2, but was %v; line was %q", len(importPathDoc), line)
+		}
+		importPath, doc := importPathDoc[0], importPathDoc[1]
+		if importPath == root {
+			continue
+		}
+		pkgs = append(pkgs, pkg{ImportPath: importPath, Doc: doc})
+	}
+	if err := cmd.Wait(); err != nil {
+		return nil, err
+	}
+	return pkgs, nil
+}


### PR DESCRIPTION
It's a list of all Go packages in the repository, listed by their relative path and package documentation string (synopsis).

Inspired by godoc.org, e.g., compare with http://godoc.org/github.com/shurcooL/cmd and https://godoc.org/golang.org/x/tools.
