### PR TITLE
gorepogen: Use 1.x notation to target latest stable Go.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ addons:
     - xorg-dev
 language: go
 go:
-  - 1.7.4
-  - tip
+  - 1.x
+  - master
 matrix:
   allow_failures:
-    - go: tip
+    - go: master
   fast_finish: true
 install:
   - # Do nothing. This is needed to prevent default install action "go get -t -v ./..." from happening here (we want it to happen inside script step).

--- a/gorepogen/main.go
+++ b/gorepogen/main.go
@@ -56,11 +56,11 @@ License
 	".travis.yml": t(`sudo: false
 language: go
 go:
-  - 1.7.4
-  - tip
+  - 1.x
+  - master
 matrix:
   allow_failures:
-    - go: tip
+    - go: master
   fast_finish: true
 install:
   - # Do nothing. This is needed to prevent default install action "go get -t -v ./..." from happening here (we want it to happen inside script step).


### PR DESCRIPTION
This way, there's no need to update .travis.yml files every time a new version of Go comes out.

Use "master" instead of "tip" since that seems to be the new name for it.

Source: https://docs.travis-ci.com/user/languages/go#Specifying-a-Go-version-to-use

Huge thanks to @mvdan and @meatballhat for uncovering this!