### PR TITLE
Add xorg-dev and libgl1-mesa-dev packages to be installed by GopherCI.

### DIFF
--- a/.gopherci.yml
+++ b/.gopherci.yml
@@ -1,0 +1,3 @@
+apt_packages:
+  - libgl1-mesa-dev
+  - xorg-dev


### PR DESCRIPTION
dumpglfw3joysticks imports glfw which has these packages as a cgo
dependency. GopherCI can't build the project unless all dependencies
are available. This change instructs GopherCI to install the packages
before the static analysis tools are ran.

See: https://gci.gopherci.io/analysis/479 (analysis of the push to my fork now succeeds)
Fixed by: https://github.com/bradleyfalzon/gopherci/issues/94